### PR TITLE
Refactor routes

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,6 +7,6 @@ class Admin::UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:user_id])
+    @user = User.find(params[:id])
   end
 end

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Change Password</h1>
-<%= form_tag "/passwords/edit", method: :patch do %>
+<%= form_tag "/passwords", method: :patch do %>
   <%= password_field_tag :password, nil, placeholder: 'New Password' %><br>
   <%= password_field_tag :password_confirmation, nil, placeholder: 'Confirm New Password' %><br>
   <%= submit_tag 'Update Password' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Edit Your Profile</h1>
-<%= form_tag "/users/edit", method: :patch do %>
+<%= form_tag "/users", method: :patch do %>
   <%= text_field_tag :name, current_user.name, placeholder: 'Name' %><br>
   <%= text_field_tag :address, current_user.address, placeholder: 'Address' %><br>
   <%= text_field_tag :city, current_user.city, placeholder: 'City' %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get "/", to: "welcome#index"
+
   namespace :admin do
     get "/", to: "dashboard#index"
 
@@ -32,27 +34,30 @@ Rails.application.routes.draw do
     # patch  "/item_orders/:id", to: "item_orders#update"
   end
 
-  get "/", to: "welcome#index"
+  resources :merchants do
+  # get "/merchants", to: "merchants#index"
+  # get "/merchants/new", to: "merchants#new"
+  # get "/merchants/:id", to: "merchants#show"
+  # post "/merchants", to: "merchants#create"
+  # get "/merchants/:id/edit", to: "merchants#edit"
+  # patch "/merchants/:id", to: "merchants#update"
+  # delete "/merchants/:id", to: "merchants#destroy"
+    resources :items, only: [:index, :new, :create]
+    # get "/merchants/:merchant_id/items", to: "items#index"
+    # get "/merchants/:merchant_id/items/new", to: "items#new"
+    # post "/merchants/:merchant_id/items", to: "items#create"
+  end
 
-  get "/merchants", to: "merchants#index"
-  get "/merchants/new", to: "merchants#new"
-  get "/merchants/:id", to: "merchants#show"
-  post "/merchants", to: "merchants#create"
-  get "/merchants/:id/edit", to: "merchants#edit"
-  patch "/merchants/:id", to: "merchants#update"
-  delete "/merchants/:id", to: "merchants#destroy"
-
-  get "/items", to: "items#index"
-  get "/items/:id", to: "items#show"
-  get "/items/:id/edit", to: "items#edit"
-  patch "/items/:id", to: "items#update"
-  get "/merchants/:merchant_id/items", to: "items#index"
-  get "/merchants/:merchant_id/items/new", to: "items#new"
-  post "/merchants/:merchant_id/items", to: "items#create"
-  delete "/items/:id", to: "items#destroy"
+  # resources :items, except: [:new, :create]
+  # get "/items", to: "items#index"
+  # get "/items/:id", to: "items#show"
+  # get "/items/:id/edit", to: "items#edit"
+  # patch "/items/:id", to: "items#update"
+  #
+  # delete "/items/:id", to: "items#destroy"
 
   resources :reviews, only: [:edit, :update, :destroy]
-  resources :items do
+  resources :items, except: [:new, :create] do
     resources :reviews, only: [:new, :create]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,19 +1,11 @@
 Rails.application.routes.draw do
-
   get "/", to: "welcome#index"
 
   namespace :admin do
     get "/", to: "dashboard#index"
-
     resources :users, only: [:index, :show]
-    # get "/users/:user_id", to: "users#show"
-    # get "/users", to: "users#index"
     resources :orders, only: [:update]
-    # patch "/orders/:id", to: "orders#update"
     resources :merchants, only: [:show, :index, :update]
-    # get "/merchants/:id", to: "merchants#show"
-    # get "/merchants", to: "merchants#index"
-    # patch "/merchants/:id", to: "merchants#update"
     get "merchants/:id/items", to: "items#index"
   end
 
@@ -21,52 +13,18 @@ Rails.application.routes.draw do
     get "/", to: "dashboard#show"
     resources :items
     match "/items/:id/update_status" => 'items#update_status', :via => :patch
-    # patch "/items/:id/update_status", to: "items#update_status"
-    # get "/items", to: "items#index"
-    # get "/items/new", to: "items#new"
-    # post "/items", to: "items#create"
-    # get '/items/:id/edit', to: 'items#edit'
-    # patch "/items/:id", to: "items#update"
-    # delete 'items/:id', to: 'items#destroy'
     resources :orders, only: [:show]
-    # get "/orders/:id", to: "orders#show"
     resources :item_orders, only: [:update]
-    # patch  "/item_orders/:id", to: "item_orders#update"
   end
 
   resources :merchants do
-  # get "/merchants", to: "merchants#index"
-  # get "/merchants/new", to: "merchants#new"
-  # get "/merchants/:id", to: "merchants#show"
-  # post "/merchants", to: "merchants#create"
-  # get "/merchants/:id/edit", to: "merchants#edit"
-  # patch "/merchants/:id", to: "merchants#update"
-  # delete "/merchants/:id", to: "merchants#destroy"
     resources :items, only: [:index, :new, :create]
-    # get "/merchants/:merchant_id/items", to: "items#index"
-    # get "/merchants/:merchant_id/items/new", to: "items#new"
-    # post "/merchants/:merchant_id/items", to: "items#create"
   end
-
-  # resources :items, except: [:new, :create]
-  # get "/items", to: "items#index"
-  # get "/items/:id", to: "items#show"
-  # get "/items/:id/edit", to: "items#edit"
-  # patch "/items/:id", to: "items#update"
-  #
-  # delete "/items/:id", to: "items#destroy"
 
   resources :reviews, only: [:edit, :update, :destroy]
   resources :items, except: [:new, :create] do
     resources :reviews, only: [:new, :create]
   end
-
-  # get "/items/:item_id/reviews/new", to: "reviews#new"
-  # post "/items/:item_id/reviews", to: "reviews#create"
-
-  # get "/reviews/:id/edit", to: "reviews#edit"
-  # patch "/reviews/:id", to: "reviews#update"
-  # delete "/reviews/:id", to: "reviews#destroy"
 
   post "/cart/:item_id", to: "cart#add_item"
   get "/cart", to: "cart#show"
@@ -75,15 +33,10 @@ Rails.application.routes.draw do
   delete "/cart/:item_id", to: "cart#remove_item"
 
   resources :orders, only: [:new, :create, :show, :destroy]
-  # get "/orders/new", to: "orders#new"
-  # post "/orders", to: "orders#create"
-  # get "/orders/:id", to: "orders#show"
-  # delete "/orders/:id", to: "orders#destroy"
 
   # PROFILE ORDERS
-  # this refactor didn't work:
-  # resources :orders, only: [:index, :show]
-  # used original
+  # refactoring this isn't worthwhile bc of the 'profile' part in the route
+  # too much functionality depends on this.
   get "/profile/orders", to: "orders#index"
   get "/profile/orders/:id", to: "orders#show"
 
@@ -99,12 +52,6 @@ Rails.application.routes.draw do
 
   # EDIT USER
   resource :users, only: [:edit, :update]
-  # get "/users/edit", to: "users#edit"
-  # patch "/users/edit", to: "users#update"
-
   # EDIT PASSWORD
   resource :passwords, only: [:edit, :update]
-  # get "passwords/edit", to: "passwords#edit"
-  # patch "passwords/edit", to: "passwords#update"
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,12 +78,12 @@ Rails.application.routes.draw do
   delete "/logout", to: "sessions#destroy"
 
   # EDIT USER
-  get "/users/edit", to: "users#edit"
-  patch "/users/edit", to: "users#update"
+  resource :users, only: [:edit, :update]
+  # get "/users/edit", to: "users#edit"
+  # patch "/users/edit", to: "users#update"
 
   # EDIT PASSWORD
   resource :passwords, only: [:edit, :update]
-
   # get "passwords/edit", to: "passwords#edit"
   # patch "passwords/edit", to: "passwords#update"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,12 +58,16 @@ Rails.application.routes.draw do
   delete "/cart", to: "cart#empty"
   delete "/cart/:item_id", to: "cart#remove_item"
 
-  get "/orders/new", to: "orders#new"
-  post "/orders", to: "orders#create"
-  get "/orders/:id", to: "orders#show"
-  delete "/orders/:id", to: "orders#destroy"
+  resources :orders, only: [:new, :create, :show, :destroy]
+  # get "/orders/new", to: "orders#new"
+  # post "/orders", to: "orders#create"
+  # get "/orders/:id", to: "orders#show"
+  # delete "/orders/:id", to: "orders#destroy"
 
   # PROFILE ORDERS
+  # this refactor didn't work:
+  # resources :orders, only: [:index, :show]
+  # used original
   get "/profile/orders", to: "orders#index"
   get "/profile/orders/:id", to: "orders#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,9 @@ Rails.application.routes.draw do
   patch "/users/edit", to: "users#update"
 
   # EDIT PASSWORD
-  get "passwords/edit", to: "passwords#edit"
-  patch "passwords/edit", to: "passwords#update"
+  resource :passwords, only: [:edit, :update]
+
+  # get "passwords/edit", to: "passwords#edit"
+  # patch "passwords/edit", to: "passwords#update"
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,15 +17,19 @@ Rails.application.routes.draw do
 
   namespace :merchant do
     get "/", to: "dashboard#show"
-    get "/items", to: "items#index"
-    get "/items/new", to: "items#new"
-    post "/items", to: "items#create"
-    get "/orders/:id", to: "orders#show"
-    get '/items/:id/edit', to: 'items#edit'
-    patch "/items/:id", to: "items#update"
-    patch "/items/:id/update_status", to: "items#update_status"
-    delete 'items/:id', to: 'items#destroy'
-    patch  "/item_orders/:id", to: "item_orders#update"
+    resources :items
+    match "/items/:id/update_status" => 'items#update_status', :via => :patch
+    # patch "/items/:id/update_status", to: "items#update_status"
+    # get "/items", to: "items#index"
+    # get "/items/new", to: "items#new"
+    # post "/items", to: "items#create"
+    # get '/items/:id/edit', to: 'items#edit'
+    # patch "/items/:id", to: "items#update"
+    # delete 'items/:id', to: 'items#destroy'
+    resources :orders, only: [:show]
+    # get "/orders/:id", to: "orders#show"
+    resources :item_orders, only: [:update]
+    # patch  "/item_orders/:id", to: "item_orders#update"
   end
 
   get "/", to: "welcome#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,15 @@
 Rails.application.routes.draw do
 
-  # Added this line because without a homepage,
-  # heroku prod won't launch the site.
   namespace :admin do
     get "/", to: "dashboard#index"
-    get "/users/:user_id", to: "users#show"
+    resources :users, only: [:index, :show]
+    # get "/users/:user_id", to: "users#show"
     patch "/orders/:id", to: "orders#update"
     get "/merchants/:id", to: "merchants#show"
     get "/merchants", to: "merchants#index"
     patch "/merchants/:id", to: "merchants#update"
     get "merchants/:id/items", to: "items#index"
-    get "/users", to: "users#index"
+    # get "/users", to: "users#index"
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,9 +48,10 @@ Rails.application.routes.draw do
   get "/items/:item_id/reviews/new", to: "reviews#new"
   post "/items/:item_id/reviews", to: "reviews#create"
 
-  get "/reviews/:id/edit", to: "reviews#edit"
-  patch "/reviews/:id", to: "reviews#update"
-  delete "/reviews/:id", to: "reviews#destroy"
+  resources :reviews, only: [:edit, :update, :destroy]
+  # get "/reviews/:id/edit", to: "reviews#edit"
+  # patch "/reviews/:id", to: "reviews#update"
+  # delete "/reviews/:id", to: "reviews#destroy"
 
   post "/cart/:item_id", to: "cart#add_item"
   get "/cart", to: "cart#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,14 +2,17 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get "/", to: "dashboard#index"
+
     resources :users, only: [:index, :show]
     # get "/users/:user_id", to: "users#show"
-    patch "/orders/:id", to: "orders#update"
-    get "/merchants/:id", to: "merchants#show"
-    get "/merchants", to: "merchants#index"
-    patch "/merchants/:id", to: "merchants#update"
-    get "merchants/:id/items", to: "items#index"
     # get "/users", to: "users#index"
+    resources :orders, only: [:update]
+    # patch "/orders/:id", to: "orders#update"
+    resources :merchants, only: [:show, :index, :update]
+    # get "/merchants/:id", to: "merchants#show"
+    # get "/merchants", to: "merchants#index"
+    # patch "/merchants/:id", to: "merchants#update"
+    get "merchants/:id/items", to: "items#index"
   end
 
   namespace :merchant do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,10 +45,14 @@ Rails.application.routes.draw do
   post "/merchants/:merchant_id/items", to: "items#create"
   delete "/items/:id", to: "items#destroy"
 
-  get "/items/:item_id/reviews/new", to: "reviews#new"
-  post "/items/:item_id/reviews", to: "reviews#create"
-
   resources :reviews, only: [:edit, :update, :destroy]
+  resources :items do
+    resources :reviews, only: [:new, :create]
+  end
+
+  # get "/items/:item_id/reviews/new", to: "reviews#new"
+  # post "/items/:item_id/reviews", to: "reviews#create"
+
   # get "/reviews/:id/edit", to: "reviews#edit"
   # patch "/reviews/:id", to: "reviews#update"
   # delete "/reviews/:id", to: "reviews#destroy"


### PR DESCRIPTION
**Refactoring rails routes for Intermission Work before Mod3.** 

Not quite sure how to use `to:` and `as:` in this context. It seems like `as:` just changes the path helper, which isn't useful if my views (forms/links) weren't written using path helpers. Adding `to:` to designate the path I actually want used doesn't seem to help with matching up those routes either.

The routes I couldn't change to use `resources` had too much interdependence with the paths written for specs and links, and I couldn't figure out an easy way to use `as:` to get around this. It felt like trying to force the use of `resources` in all cases was a bit like using the wrong tool for the job.

Discovered you can use `resource` instead of `resources` when you don't want to reference a specific resource ID in the path. Not sure what the unseen repercussions of this method are.

Would love more clarification on how I could have refactored all the routes using `as:` without having to change anything in my specs or views. 